### PR TITLE
Return twirp errors from the auth handlers

### DIFF
--- a/cmd/dsctl/main.go
+++ b/cmd/dsctl/main.go
@@ -11,8 +11,8 @@ import (
 )
 
 func main() {
-	addr := flag.String("addr", "localhost:50051", "the address to connect to")
-	user := flag.String("username", "john", "Username")
+	addr := flag.String("addr", "localhost:8080", "the address to connect to")
+	user := flag.String("username", "", "Username")
 	pass := flag.String("password", "doe", "password")
 	flag.Parse()
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/tabboud/directory-service/rpc/authservice"
+	"github.com/twitchtv/twirp"
 )
 
 type TokenProvider interface {
@@ -25,9 +26,24 @@ func NewService(tp TokenProvider, ttl int) *Service {
 }
 
 func (s *Service) Login(ctx context.Context, req *authservice.LoginRequestV1) (*authservice.LoginResponseV1, error) {
-	// TODO(tabboud): validate request and return twirp errors (although that couples us to twirp RPC)
+	if req == nil {
+		return nil, twirp.NewError(twirp.InvalidArgument, "login request cannot be empty")
+	}
+	if err := validateRequest(req); err != nil {
+		return nil, err
+	}
 	return &authservice.LoginResponseV1{
 		AccessToken: s.tokenProvider.GetToken(ctx),
 		ExpiresIn:   int64(s.ttl),
 	}, nil
+}
+
+func validateRequest(req *authservice.LoginRequestV1) error  {
+	if req.Username == "" {
+		return twirp.NewError(twirp.InvalidArgument, "login username cannot be empty")
+	}
+	if req.Password == "" {
+		return twirp.NewError(twirp.InvalidArgument, "login password cannot be empty")
+	}
+	return nil
 }


### PR DESCRIPTION
This exposes the RPC layer within the service handlers, but that seems like a fine compromise given it's also what conjure does.